### PR TITLE
fix doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ println("Hello World")
 
 Variables are used to store the value of specific type, the types supported by kotlin there in documentation
 
-Documentation: [https://kotlinlang.org/docs/reference/basic-types.html](https://kotlinlang.org/docs/reference/basic-types.html)[https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/)
+Documentation: [https://kotlinlang.org/docs/reference/basic-types.html](https://kotlinlang.org/docs/reference/basic-types.html), [https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/)
 
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ println("Hello World")
 
 Variables are used to store the value of specific type, the types supported by kotlin there in documentation
 
-Documentation: [https://kotlinlang.org/docs/reference/basic-types.html, https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/](https://kotlinlang.org/docs/reference/basic-types.html, https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/)
+Documentation: [https://kotlinlang.org/docs/reference/basic-types.html](https://kotlinlang.org/docs/reference/basic-types.html)[https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/)
 
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ fun main(args: Array<String>) {
 
 ## Printing on the console
 
-Documentation: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/println.html#println
+Documentation: [https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/println.html#println](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/println.html#println)
 
 
 ```kotlin
@@ -38,7 +38,7 @@ println("Hello World")
 
 Variables are used to store the value of specific type, the types supported by kotlin there in documentation
 
-Documentation: https://kotlinlang.org/docs/reference/basic-types.html, https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/
+Documentation: [https://kotlinlang.org/docs/reference/basic-types.html, https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/](https://kotlinlang.org/docs/reference/basic-types.html, https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/)
 
 
 ```kotlin


### PR DESCRIPTION
fix the links to Kotlin docs, to be clickable in Github page view.

fixed only 2 first links, if it's ok, i'll fix all.